### PR TITLE
Enable control characters for form feed and vertical tab

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -78,7 +78,7 @@ func init() {
 
 	rRange.Ope = Cho(Seq(&rChar, Lit("-"), &rChar), &rChar)
 	rChar.Ope = Cho(
-		Seq(Lit("\\"), Cls("nrt'\"[]\\")),
+		Seq(Lit("\\"), Cls("nrtfv'\"[]\\")),
 		Seq(Lit("\\"), Cls("0-3"), Cls("0-7"), Cls("0-7")),
 		Seq(Lit("\\"), Cls("0-7"), Opt(Cls("0-7"))),
 		Seq(Lit("\\x"), Cls("0-9a-fA-F"), Opt(Cls("0-9a-fA-F"))),
@@ -383,6 +383,12 @@ func resolveEscapeSequence(s string) string {
 				i++
 			case 't':
 				b = append(b, '\t')
+				i++
+			case 'f':
+				b = append(b, '\f')
+				i++
+			case 'v':
+				b = append(b, '\v')
 				i++
 			case '\'':
 				b = append(b, '\'')

--- a/parser_test.go
+++ b/parser_test.go
@@ -1146,6 +1146,8 @@ func TestPegChar(t *testing.T) {
 	match(t, &rChar, "\\n", true)
 	match(t, &rChar, "\\r", true)
 	match(t, &rChar, "\\t", true)
+	match(t, &rChar, "\\f", true)
+	match(t, &rChar, "\\v", true)
 	match(t, &rChar, "\\'", true)
 	match(t, &rChar, "\\\"", true)
 	match(t, &rChar, "\\[", true)


### PR DESCRIPTION
Hello Hirose-san,

This commit enables control characters(`¥f` and `¥v`).