### PR TITLE
Follow the practice for error handling in Go

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -75,7 +75,7 @@ func (p *Parser) EnableAst() (err error) {
 	return err
 }
 
-func (p *Parser) ParseAndGetAst(s string, d Any) (ast *Ast, err *Error) {
+func (p *Parser) ParseAndGetAst(s string, d Any) (ast *Ast, err error) {
 	if val, err := p.ParseAndGetValue(s, d); err == nil {
 		ast = val.(*Ast)
 	}

--- a/expr.go
+++ b/expr.go
@@ -124,7 +124,7 @@ func Exp(atom operator, binop operator, bopinf BinOpeInfo, action *Action) opera
 	return o
 }
 
-func EnableExpressionParsing(p *Parser, name string, bopinf BinOpeInfo) *Error {
+func EnableExpressionParsing(p *Parser, name string, bopinf BinOpeInfo) error {
 	if r, ok := p.Grammar[name]; ok {
 		seq := r.Ope.(*sequence)
 		atom := seq.opes[0].(*reference)

--- a/parser.go
+++ b/parser.go
@@ -468,11 +468,11 @@ type Parser struct {
 	TracerLeave func(name string, s string, v *Values, d Any, p int, l int)
 }
 
-func NewParser(s string) (p *Parser, err *Error) {
+func NewParser(s string) (p *Parser, err error) {
 	return NewParserWithUserRules(s, nil)
 }
 
-func NewParserWithUserRules(s string, rules map[string]operator) (p *Parser, err *Error) {
+func NewParserWithUserRules(s string, rules map[string]operator) (p *Parser, err error) {
 	data := newData()
 
 	_, _, err = rStart.Parse(s, data)
@@ -504,7 +504,7 @@ func NewParserWithUserRules(s string, rules map[string]operator) (p *Parser, err
 		for _, dup := range data.duplicates {
 			ln, col := lineInfo(s, dup.pos)
 			msg := "'" + dup.name + "' is already defined."
-			err.Details = append(err.Details, ErrorDetail{ln, col, msg})
+			err.(*Error).Details = append(err.(*Error).Details, ErrorDetail{ln, col, msg})
 		}
 	}
 
@@ -523,7 +523,7 @@ func NewParserWithUserRules(s string, rules map[string]operator) (p *Parser, err
 			}
 			ln, col := lineInfo(s, pos)
 			msg := v.errorMsg[name]
-			err.Details = append(err.Details, ErrorDetail{ln, col, msg})
+			err.(*Error).Details = append(err.(*Error).Details, ErrorDetail{ln, col, msg})
 		}
 	}
 
@@ -556,7 +556,7 @@ func NewParserWithUserRules(s string, rules map[string]operator) (p *Parser, err
 			}
 			ln, col := lineInfo(s, v.pos)
 			msg := "'" + name + "' is left recursive."
-			err.Details = append(err.Details, ErrorDetail{ln, col, msg})
+			err.(*Error).Details = append(err.(*Error).Details, ErrorDetail{ln, col, msg})
 		}
 	}
 
@@ -586,12 +586,12 @@ func NewParserWithUserRules(s string, rules map[string]operator) (p *Parser, err
 	return
 }
 
-func (p *Parser) Parse(s string, d Any) (err *Error) {
+func (p *Parser) Parse(s string, d Any) (err error) {
 	_, err = p.ParseAndGetValue(s, d)
 	return
 }
 
-func (p *Parser) ParseAndGetValue(s string, d Any) (val Any, err *Error) {
+func (p *Parser) ParseAndGetValue(s string, d Any) (val Any, err error) {
 	r := p.Grammar[p.start]
 	r.TracerEnter = p.TracerEnter
 	r.TracerLeave = p.TracerLeave

--- a/parser_test.go
+++ b/parser_test.go
@@ -249,10 +249,13 @@ func TestEnterExitHandlers(t *testing.T) {
 	assert(t, parser.Parse("hello=WORLD", d) == nil)
 	assert(t, parser.Parse("HELLO=WORLD", d) == nil)
 
-	err := parser.Parse("hello=world", d)
-	assert(t, err.Details[0].Ln == 1)
-	assert(t, err.Details[0].Col == 7)
-	assert(t, err.Details[0].Msg == msg)
+	var err error
+	err = parser.Parse("hello=world", d)
+	pegErr, ok := err.(*Error)
+	assert(t, ok)
+	assert(t, pegErr.Details[0].Ln == 1)
+	assert(t, pegErr.Details[0].Col == 7)
+	assert(t, pegErr.Details[0].Msg == msg)
 }
 
 func TestWhitespace(t *testing.T) {

--- a/rule.go
+++ b/rule.go
@@ -49,7 +49,7 @@ type Rule struct {
 	disableAction bool
 }
 
-func (r *Rule) Parse(s string, d Any) (l int, val Any, err *Error) {
+func (r *Rule) Parse(s string, d Any) (l int, val Any, err error) {
 	v := &Values{}
 	c := &context{
 		s:             s,
@@ -89,7 +89,7 @@ func (r *Rule) Parse(s string, d Any) (l int, val Any, err *Error) {
 		}
 		ln, col := lineInfo(s, pos)
 		err = &Error{}
-		err.Details = append(err.Details, ErrorDetail{ln, col, msg})
+		err.(*Error).Details = append(err.(*Error).Details, ErrorDetail{ln, col, msg})
 	}
 
 	return


### PR DESCRIPTION
Hello Hirose-san,

**This pull request contains breaking changes.**

It follows the practice for error handling in Go. ([error-handling-and-go](https://blog.golang.org/error-handling-and-go))
Specifically, change the function return value to type `error`.

Below is the code causing problem:
```go
package main

import (
        "fmt"
        "github.com/yhirose/go-peg"
)

func main() {
        var err error
        _, err = peg.NewParser("ROOT <- [a-z]+")
        if err != nil {
                fmt.Printf("err is not nil : %#v\n", err)
        } else {
                fmt.Println("err is nil")
        }
}
```
Output:
`err is not nil : (*peg.Error)(nil)`

For a deep explanation, please refer to the following.
- [Why is my nil error value not equal to nil?](https://golang.org/doc/faq#nil_error)
- [interface とnil](http://www.yunabe.jp/docs/golang_pitfall.html#interface-nil-gointerface) (Japanese)

----
When we need specific error handling:
```go
_, err := peg.NewParser("ROOT <- [a-z]+")
if err != nil {
        if pegErr, ok := err.(*peg.Error); ok {
                // `peg.Error` handling
        } else {
                // other error handling
        }
```