### PR TITLE
Updater error reporting architecture, to support more informative err…

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,8 @@
 package peg
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	WhitespceRuleName = "%whitespace"
@@ -52,7 +54,7 @@ func init() {
 		Seq(&rIgnore, &rIdentifier, &rLEFTARROW, &rExpression))
 
 	rExpression.Ope = Seq(&rSequence, Zom(Seq(&rSLASH, &rSequence)))
-	rSequence.Ope = Zom(&rPrefix)
+	rSequence.Ope = Oom(&rPrefix)
 	rPrefix.Ope = Seq(Opt(Cho(&rAND, &rNOT)), &rSuffix)
 	rSuffix.Ope = Seq(&rPrimary, Opt(Cho(&rQUESTION, &rSTAR, &rPLUS)))
 


### PR DESCRIPTION
…or messages.

Known limitations on this update:
* Errors occurring in Kleene-star operators (Oom or Zom) do not return, due to the nature of the operators. This has the effect of masking some errors, if there was a legitimate syntax error.